### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,55 @@
 # IMT-Hydra
 
-Repository for the Scripps Institute of Oceanography IMT Lab's Hydra project.
+This repository contains software for the Scripps Institution of Oceanography IMT Lab's Hydra project. The platform integrates multiple sensors and cameras running on single board computers (SBCs).
 
-**WIP - Repo structure is not finalized**
+## Repository structure
 
-Repository Structure:
+- `sensor-modules/` – all sensor and camera code
+- `experiment/` – prototype scripts exploring threading and pub/sub patterns
+- `system-outline/` – architectural notes and diagrams
+- `DEV_GUIDE.md` – brief notes for developers
 
-- setup-scripts (TODO)
-- sensor-modules
-- experiment
+Other folders may appear as the project evolves.
 
-### Expected Launch: February 2023
+## Development log
 
-# Spring Quarter
+The sections below capture meeting notes and progress during early development.
 
-## Week 2
+### Spring Quarter
 
-Questions for meeting
-
+#### Week 2
 - What times work best for undergrad meeting? _TBD_
 - Can we just use the GPS to set system time of the SBCs? _Do we need 1pps and if so how would we use it? Log 1pps pulse with measurement logs and sync them up later. Find out how to connect GPS with Latte Pandas._
 - What logging convention should we use (for cams, for SITA/MET1)? _Low data rate. Human readable. Serves as activity log for cameras._
-- Recruiting: _Job posting. Share with student-orgs: ACM, Triton Robotics (tritonrobotics@ucsd.edu)._
-
+- Recruiting: _Job posting. Share with student-orgs: ACM, Triton Robotics (tritonrobotics@ucsd.edu)._ 
 - [x] GPS time logging for RPi
 - [x] Implement cam Module (composition)
 
-## Week 3
-
+#### Week 3
 - [x] Implement logger module (concurrent to bubblecam)
 - [x] Implement bubblecam module (compisition)
 
-## Week 4
-
-Questions for meeting
-
+#### Week 4
 - What lockout time are we expecting? (currently averaging 3.3 seconds for 150-image write -- slow at the start) _30 seconds_
 - For the buffer, is there a rate of capture that we want, or do we want every single frame (according to the cam fps)? _10fps for bubblecam/foamcam, 1 frame white cap cam_
 - What size buffer do we want? (seconds into frames) _5 seconds back and 5 seconds forward, 100 frames total_
 - What format do we want to write data in? (currently png) _no compression_
 - Data validation to get rid of less interesting images
-
 - [x] Test logger module
 - [x] Test reimplementation of bubblecam (current functionality + data quality check)
 
-## Week 5
-
-Questions for meeting
-
+#### Week 5
 - When camera is locked out, do we still want to capture images in the buffer?
 - Will I be able to come into the lab next week?
-
 - [x] Make fixes to bubblecam and test again
 - [x] Devise more tests for edge cases
 
-## Week 6
-
-Points for meeting
-
+#### Week 6
 - Bubblecam cannot ssh
 - Other tests to consider
 - Behrad software
 
-## Week 10
+#### Week 10
 - [ ] Finalize bubblecam
   - [x] Finish thread testing
   - [X] Refine logging format
@@ -71,13 +58,13 @@ Points for meeting
 - [X] Reimplement foam and white cap cam
 - [ ] Test reimplementation of foam and white cap cam
 
-## Beyond
+#### Beyond
 - [ ] Implement pub/sub for state between RPi (supervisor) and cams (Latte Pandas)
 - [ ] GPS time logging for Latte Pandas
 - [ ] Get MET1 feather working with the supervisor
 - [ ] Test SITA and MET1
 - [ ] Implement Power Module
 
-## Other
+#### Other
 - [ ] Onboard Behrad to software
 - [ ] Job description for software

--- a/experiment/README.md
+++ b/experiment/README.md
@@ -1,0 +1,6 @@
+# Experiment
+
+This directory contains small prototype scripts used to test multiprocessing and communication patterns. They are not part of the main Hydra modules but serve as references for future development.
+
+- `producer_consumer/` — experiments with Python threads and queues
+- `pubsub_zmq/` — minimal examples using ZeroMQ for publish/subscribe messaging

--- a/experiment/producer_consumer/README.md
+++ b/experiment/producer_consumer/README.md
@@ -1,0 +1,1 @@
+Simple experiment demonstrating the producer/consumer pattern with Python threads and queues.

--- a/experiment/pubsub_zmq/README.md
+++ b/experiment/pubsub_zmq/README.md
@@ -1,0 +1,1 @@
+Minimal ZeroMQ publish/subscribe example used to explore messaging between processes.

--- a/sensor-modules/README.md
+++ b/sensor-modules/README.md
@@ -1,0 +1,9 @@
+# Sensor Modules
+
+All code for interacting with the Hydra sensors lives here. Each subdirectory corresponds to a category of devices or supporting documentation.
+
+- `cameras/` — camera driver implementations
+- `c-sensors/` — "c" sensor modules (GPS, MET1, SITA, etc.)
+- `compositions/` — higher level modules that combine sensors together
+- `sensor-docs/` — notes and guides for operating sensors
+- `tests/` — test suites for the sensor code

--- a/sensor-modules/c-sensors/README.md
+++ b/sensor-modules/c-sensors/README.md
@@ -1,0 +1,9 @@
+# C Sensors
+
+Modules for sensors other than the cameras. Each subfolder contains the code for a specific device.
+
+- `gps/` – GPS receiver interface
+- `met1/` – air particle counter (MET1)
+- `sita/` – SITA serial device
+
+The `sensor.py` file defines common base functionality shared across these modules.

--- a/sensor-modules/c-sensors/gps/README.md
+++ b/sensor-modules/c-sensors/gps/README.md
@@ -1,5 +1,5 @@
-Code for the IMT Hydra GPS Module. The GPS used will be provided by the Liquid Robotics sensor systems, but the code
-will be customized for the Hydra's mission.
+# GPS Module
 
-The GPS module should process NMEA strings sent via digital lines and also handle signal interrupts from a 1pps line
-toggled by the GPS.
+Interface code for the Hydra GPS receiver. The hardware originates from the Liquid Robotics sensor suite, but the logic here is tailored for Hydra.
+
+The module parses NMEA messages from the device and also handles the 1 PPS signal used for precise time synchronization.

--- a/sensor-modules/c-sensors/met1/README.md
+++ b/sensor-modules/c-sensors/met1/README.md
@@ -1,6 +1,5 @@
-Sensor module for IMT Hydra's MET1, also known as the air particle counter (apc).
+# MET1 Module
 
-Samples every 1/2 hour, 24/7 unless LOCKDOWN mode has been engaged, wherein windspeed is too high for the met1 to safely
-operate.
+Code for interfacing with the MET1 air particle counter.
 
-The Met1 will be operated through calling functions implemented in the Feather microcontroller that uses UART.
+Hydra samples the MET1 every 30 minutes unless the platform enters LOCKDOWN due to high winds. Communication with the device happens through a Feather microcontroller over UART.

--- a/sensor-modules/c-sensors/sita/README.md
+++ b/sensor-modules/c-sensors/sita/README.md
@@ -1,3 +1,3 @@
-IMT Hydra's SITA module. Uses serial comms to interface/control the SITA device.
+# SITA Module
 
-Sample every 1/2 hour, 24/7.
+Controls the SITA water sampler via serial communication. Sampling occurs every 30 minutes and runs continuously throughout the mission.

--- a/sensor-modules/c-sensors/sita/sita-serial-old/README.md
+++ b/sensor-modules/c-sensors/sita/sita-serial-old/README.md
@@ -1,7 +1,1 @@
-Old sita code, with some other exploratory code that was originally on the supervisor sbc.
-
-Sita example code lies in GetSerial.py and SitaSerialTest.py with example outputs from these programs in the .txt files.
-
-Other code explored pub/sub comms, 1pps signal interrupts/handler, and remote power toggling. Feel free to ignore these
-files,
-but they're included in order to accurately capture this aspect of the old supervisor's codebase.
+Legacy SITA serial experiments kept for reference. `GetSerial.py` and `SitaSerialTest.py` contain example code and logs. Other files explore pub/sub messaging, handling the GPS 1 PPS signal, and remote power control.

--- a/sensor-modules/cameras/README.md
+++ b/sensor-modules/cameras/README.md
@@ -1,0 +1,9 @@
+# Cameras
+
+Drivers and utilities for Hydra's camera systems. This directory contains both the original camera implementations and newer composition based approaches.
+
+- `compositions/` – modern camera modules built using composition
+- `old_cameras/` – legacy camera code
+- `config/` – configuration files
+- `tests/` – camera test suites
+- `sensor.py` and `state.py` – common helper classes

--- a/sensor-modules/cameras/old_cameras/README.md
+++ b/sensor-modules/cameras/old_cameras/README.md
@@ -1,4 +1,3 @@
-# Module for the 3 cameras
-1. Bubble Cam
-2. Foam Cam
-3. White Cap Cam
+# Legacy Camera Modules
+
+Original implementations of the bubble, foam, and whitecap cameras. These have been superseded by the composition based approach but remain for historical reference.

--- a/sensor-modules/compositions/README.md
+++ b/sensor-modules/compositions/README.md
@@ -1,0 +1,3 @@
+# Compositions
+
+High level modules that tie together multiple sensor components. Currently only the `bubblecam` composition is provided.

--- a/sensor-modules/sensor-docs/README.md
+++ b/sensor-modules/sensor-docs/README.md
@@ -1,0 +1,8 @@
+# Sensor Documentation
+
+Additional notes and guides for working with the sensors.
+
+- `data-checking.md` — ideas for filtering images before storing
+- `ssh-guide.md` — instructions for remote access
+- `storage.md` — thoughts on managing Raspberry Pi storage
+- `time-syncing.md` — approach for synchronizing system clocks

--- a/sensor-modules/tests/README.md
+++ b/sensor-modules/tests/README.md
@@ -1,0 +1,3 @@
+# Sensor Tests
+
+Collection of small test programs for validating the sensor modules. Currently includes bubble camera tests.

--- a/system-outline/README.md
+++ b/system-outline/README.md
@@ -1,0 +1,14 @@
+# System Outline
+
+This folder contains documentation for Hydra's architecture. Each markdown file describes a specific subsystem or requirement.
+
+- `overview.md` – high level description of SBC responsibilities
+- `system-reqs.md` – feature requirements
+- `system-specs.md` – hardware specifications
+- `camera.md` – camera subsystem notes
+- `sensor.md` – other sensor modules
+- `time_synchronization.md` – time syncing approach
+- `storage_management.md` – data storage considerations
+- `notes.md` – assorted design notes
+
+Diagrams such as `comms_state_diagram.png` and `cams_pseudocode.png` complement the text.


### PR DESCRIPTION
## Summary
- rewrite project README
- add README to experiments
- document sensor modules and subfolders
- provide overview readme for system-outline
- clarify existing sensor readmes

## Testing
- `pytest -q` *(fails: No module named 'serial', 'cv2', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6883ae23de8083219d266078a3bff5ec