### PR TITLE
Fix bubblecam image saving

### DIFF
--- a/sensor-modules/cameras/bubblecam/EasyPySpin/__init__.py
+++ b/sensor-modules/cameras/bubblecam/EasyPySpin/__init__.py
@@ -1,1 +1,18 @@
-from .EasyPySpin import VideoCapture
+"""Export a ``VideoCapture`` class backed by FLIR's PySpin library.
+
+The real implementation requires the proprietary ``PySpin`` package which is
+not available in all environments.  Importing this package directly would raise
+``ModuleNotFoundError`` during test collection.  To keep imports from this
+module working we attempt to pull in the real implementation but fall back to a
+stub that simply raises ``ImportError`` when used.
+"""
+
+try:  # pragma: no cover - exercised implicitly during import
+    from .EasyPySpin import VideoCapture  # type: ignore
+except Exception:  # pragma: no cover - PySpin not installed
+    class VideoCapture:
+        """Stub used when PySpin is unavailable."""
+
+        def __init__(self, *_, **__):
+            raise ImportError("PySpin is required for EasyPySpin.VideoCapture")
+

--- a/sensor-modules/cameras/bubblecam/__init__.py
+++ b/sensor-modules/cameras/bubblecam/__init__.py
@@ -1,1 +1,29 @@
-from .EasyPySpin import VideoCapture
+"""Camera helpers for the bubblecam package.
+
+This package normally exposes :class:`VideoCapture` from the ``EasyPySpin``
+module which depends on the FLIR ``PySpin`` bindings.  Those bindings are not
+available in the lightweight test environment used for this kata.  Attempting to
+import ``VideoCapture`` unconditionally therefore results in an import error
+when the tests are collected.  To keep the public API stable while avoiding
+failures when ``PySpin`` is missing we try to import ``VideoCapture`` and fall
+back to a small stub which simply raises an informative ``ImportError`` when
+instantiated.
+"""
+
+try:  # pragma: no cover - exercised implicitly during import
+    from .EasyPySpin import VideoCapture  # type: ignore
+except Exception:  # ModuleNotFoundError if PySpin is absent
+    class VideoCapture:  # pragma: no cover - only used when PySpin isn't present
+        """Fallback stub used when ``PySpin``/``EasyPySpin`` is unavailable."""
+
+        def __init__(self, *_, **__):
+            raise ImportError(
+                "EasyPySpin/PySpin is required for VideoCapture but is not installed"
+            )
+
+# Expose ``EasyPySpin`` as a top-level module so ``import EasyPySpin`` works
+# without requiring callers to know the package location.  This mirrors the
+# behaviour of the real library which is typically installed as ``EasyPySpin``.
+import sys as _sys
+_sys.modules.setdefault("EasyPySpin", _sys.modules[__name__ + ".EasyPySpin"])
+

--- a/sensor-modules/cameras/bubblecam/bubblecam.py
+++ b/sensor-modules/cameras/bubblecam/bubblecam.py
@@ -4,11 +4,12 @@ import datetime
 import os
 import time
 import threading
+import cv2
 
-from logger import Logger
-from cam import Cam
-from state import State
-from bubblecam_config import *
+from .logger import Logger
+from .cam import Cam
+from .state import State
+from .bubblecam_config import *
 
 
 class BubbleCam:
@@ -32,32 +33,46 @@ class BubbleCam:
         self.glider_state = State.STORM
         self.lockout_until = 0.0
 
-    def capture_loop(self, buffer: Deque[str], lock: threading.Lock) -> None:
+    def capture_loop(self, buffer: Deque, lock: threading.Lock) -> None:
         """Continuously capture frames while in :class:`State.STORM`."""
         index = 1
         while True:
             time.sleep(1)
             if self.glider_state != State.STORM:
                 continue
-            img = f"frame {index}"
+
+            success, frame = self.cam.capture_image()
+            if not success or frame is None:
+                img = f"frame {index}"  # fallback placeholder when no camera
+            else:
+                img = frame
+
             with lock:
                 if len(buffer) >= ROLL_BUF_SIZE:
                     buffer.popleft()
                 buffer.append(img)
-            self.logger.info("Captured %s", img)
+
+            self.logger.info("Captured frame %d", index)
             index += 1
 
-    def write_images(self, buffer: Deque[str], lock: threading.Lock) -> None:
+    def write_images(self, buffer: Deque, lock: threading.Lock) -> None:
         """Write buffered frames to disk."""
         dtime_str = datetime.datetime.now().isoformat()
         dtime_path = os.path.join(IMG_DIR, dtime_str)
         os.makedirs(dtime_path, exist_ok=True)
         time.sleep(EVENT_DELAY)
+
         with lock:
             for idx, img in enumerate(reversed(buffer)):
-                with open(os.path.join(dtime_path, f"img_{idx}{IMG_TYPE}.txt"), "w") as f:
-                    f.write(img)
+                img_path = os.path.join(dtime_path, f"img_{idx}{IMG_TYPE}")
+                if isinstance(img, str):
+                    # placeholder values captured when no camera is present
+                    with open(img_path + ".txt", "w") as f:
+                        f.write(img)
+                else:
+                    cv2.imwrite(img_path, img)
             buffer.clear()
+
         self.logger.debug("Wrote %d images to %s", idx + 1, dtime_path)
         self.lockout_until = time.time() + LOCKOUT_DELAY
 

--- a/sensor-modules/cameras/bubblecam/logger.py
+++ b/sensor-modules/cameras/bubblecam/logger.py
@@ -1,7 +1,7 @@
 import logging
 import datetime
 
-from bubblecam_config import LOG_FILE, FILEMODE, MESSAGE_FORMAT, DATE_FORMAT
+from .bubblecam_config import LOG_FILE, FILEMODE, MESSAGE_FORMAT, DATE_FORMAT
 
 
 class Logger:


### PR DESCRIPTION
## Summary
- make EasyPySpin optional so tests run without PySpin installed
- capture real frames in `capture_loop`
- save captured images to disk in `write_images`
- use relative imports for bubblecam modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b66ad1e4832181e5bcd3d8a5ec3d