### PR TITLE
Add bubblecam trigger notes

### DIFF
--- a/sensor-modules/c-sensors/conductivity_sensor/mainwindow.py
+++ b/sensor-modules/c-sensors/conductivity_sensor/mainwindow.py
@@ -321,5 +321,11 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             self.zmq_socket.send_string("trigger")
             self.console_append("Sent BubbleCam trigger.")
+            if self.notes_file:
+                ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                self.notes_file.write(
+                    f"{ts} | {self.base_filename}.csv | BubbleCam triggered\n"
+                )
+                self.console_append("[NOTE] BubbleCam triggered")
         except Exception as exc:
             self.console_append(f"Failed to send trigger: {exc}")


### PR DESCRIPTION
## Summary
- automatically add timestamped BubbleCam trigger notes when the trigger button is pressed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b91ac9c8832190cfe02c1c482b55