### PR TITLE
Fix bubblecam capture logic

### DIFF
--- a/sensor-modules/cameras/bubblecam/cam.py
+++ b/sensor-modules/cameras/bubblecam/cam.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Callable, Deque, Optional
+from typing import Callable, Deque
 
 import cv2
 
@@ -32,17 +32,22 @@ class Cam:
         self.event_delay = event_delay
         self.image_type = image_type
         self.buffer_size = buffer_size
-        # In a real deployment this would be cv2.VideoCapture(0)
-        self.camera: Optional[cv2.VideoCapture] = None
+
+        # Initialize the video capture device immediately.  If no camera is
+        # present this will still construct the ``VideoCapture`` object, but
+        # ``isOpened`` can be checked by callers if needed.  Making the camera
+        # handle mandatory ensures that frame capture attempts go through OpenCV
+        # rather than falling back to placeholder strings.
+        self.camera: cv2.VideoCapture = cv2.VideoCapture(0)
 
     def start_workflow(self, buffer: Deque, lock) -> None:
         """Start capturing images using ``capture_function``."""
         self.capture_function(buffer, lock)
 
     def capture_image(self):
-        """Capture a single frame (stubbed for tests)."""
-        if self.camera is None:
-            return True, None
+        """Capture a single frame from the camera."""
+        if not self.camera.isOpened():
+            return False, None
         return self.camera.read()
 
     def power_off(self) -> None:


### PR DESCRIPTION
## Summary
- require OpenCV VideoCapture in camera wrapper
- log capture failures instead of writing placeholder text files
- skip invalid frames when writing images

## Testing
- `python -m py_compile sensor-modules/cameras/bubblecam/bubblecam.py sensor-modules/cameras/bubblecam/cam.py`
- `pytest -q` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_6887bd56076083218a7cff28404a57b1