### PR TITLE
Automatically reset bubble camera on capture failures

### DIFF
--- a/sensor-modules/cameras/bubblecam/bubblecam.py
+++ b/sensor-modules/cameras/bubblecam/bubblecam.py
@@ -37,10 +37,22 @@ class BubbleCam:
         """Continuously capture frames while in :class:`State.STORM`."""
         index = 1
         while True:
-            success, frame = self.cam.capture_image()
+            try:
+                success, frame = self.cam.capture_image()
+            except Exception as exc:
+                self.logger.error(
+                    "Camera error while capturing frame %d: %s", index, exc
+                )
+                self.cam.reset()
+                time.sleep(1)
+                continue
 
             if not success or frame is None:
-                self.logger.warning("Failed to capture frame %d", index)
+                self.logger.warning(
+                    "Failed to capture frame %d; resetting camera", index
+                )
+                self.cam.reset()
+                time.sleep(1)
                 continue
 
             if self.glider_state != State.STORM:

--- a/sensor-modules/cameras/bubblecam/main.py
+++ b/sensor-modules/cameras/bubblecam/main.py
@@ -24,6 +24,11 @@ if __name__ == "__main__":
     capture_started = False
 
     while True:
+        if capture_started and not capture_thread.is_alive():
+            bubblecam.cam.reset()
+            capture_thread = threading.Thread(target=bubblecam.capture_loop, args=(queue, lock))
+            capture_thread.start()
+
         # non-blocking check for trigger messages
         try:
             msg = socket.recv_string(flags=zmq.NOBLOCK)


### PR DESCRIPTION
## Summary
- handle camera connection issues by resetting the Cam instance when captures fail
- reopen camera on reset and retry capture loop
- restart capture thread automatically if it dies

## Testing
- `pip install opencv-python-headless`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'logger')*
- `PYTHONPATH=sensor-modules/cameras/bubblecam pytest sensor-modules/cameras/bubblecam/tests -q` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68915ae683788321a8611922b312c17a