### PR TITLE
Allow specifying camera IDs

### DIFF
--- a/sensor-modules/cameras/README.md
+++ b/sensor-modules/cameras/README.md
@@ -9,3 +9,11 @@ Currently two FLIR based cameras are supported:
   own configuration.
 
 Shared functionality lives in ``sensor-modules/cameras/common``.
+
+## Camera Selection
+
+Each camera's configuration file now defines a ``CAMERA_ID`` setting used to
+select the hardware device.  The identifier can be either an integer index,
+the camera's serial number or a device path (e.g. ``/dev/video2``).  This
+allows multiple cameras such as BubbleCam and FoamCam to operate on the same
+machine without conflicting over device ``0``.

--- a/sensor-modules/cameras/bubblecam/config.py
+++ b/sensor-modules/cameras/bubblecam/config.py
@@ -27,6 +27,7 @@ BRIGHTNESS = 10
 GAMMA = 0.25
 FPS = 8
 BACKLIGHT = 1
+CAMERA_ID = 0
 
 ########### Logging Constants ###########
 # Name of file to log to

--- a/sensor-modules/cameras/common/cam.py
+++ b/sensor-modules/cameras/common/cam.py
@@ -1,4 +1,4 @@
-from typing import Callable, Deque
+from typing import Callable, Deque, Union
 
 import cv2
 import time
@@ -16,6 +16,7 @@ class Cam:
         self,
         name: str,
         capture_function: Callable,
+        camera_id: Union[int, str],
         exposure: int,
         gain: int,
         brightness: int,
@@ -28,6 +29,7 @@ class Cam:
     ) -> None:
         self.name = name
         self.capture_function = capture_function
+        self.camera_id = camera_id
         self.exposure = exposure
         self.gain = gain
         self.brightness = brightness
@@ -60,7 +62,7 @@ class Cam:
         """(Re)initialize the camera with the configured parameters."""
         if SpinVideoCapture is not None:
             try:
-                self.camera = SpinVideoCapture(0)
+                self.camera = SpinVideoCapture(self.camera_id)
                 self.camera.set(cv2.CAP_PROP_EXPOSURE, self.exposure)
                 self.camera.set(cv2.CAP_PROP_GAIN, self.gain)
                 self.camera.set(cv2.CAP_PROP_BRIGHTNESS, self.brightness)
@@ -70,7 +72,7 @@ class Cam:
                 return
             except Exception:
                 pass
-        self.camera = cv2.VideoCapture(0)
+        self.camera = cv2.VideoCapture(self.camera_id)
         self.camera.set(cv2.CAP_PROP_EXPOSURE, self.exposure)
         self.camera.set(cv2.CAP_PROP_GAIN, self.gain)
         self.camera.set(cv2.CAP_PROP_BRIGHTNESS, self.brightness)

--- a/sensor-modules/cameras/common/camera.py
+++ b/sensor-modules/cameras/common/camera.py
@@ -27,6 +27,7 @@ class Camera:
         self.cam = Cam(
             name,
             self.capture_loop,
+            config.CAMERA_ID,
             config.EXPOSURE,
             config.GAIN,
             config.BRIGHTNESS,

--- a/sensor-modules/cameras/foamcam/config.py
+++ b/sensor-modules/cameras/foamcam/config.py
@@ -27,6 +27,7 @@ BRIGHTNESS = 10
 GAMMA = 0.25
 FPS = 8
 BACKLIGHT = 1
+CAMERA_ID = 1
 
 ########### Logging Constants ###########
 # Name of file to log to


### PR DESCRIPTION
## Summary
- allow Cam to open specific camera by configurable ID or path
- add `CAMERA_ID` to bubblecam and foamcam configs and document usage

## Testing
- `pytest` *(fails: ImportError and ModuleNotFoundError for cv2)*

------
https://chatgpt.com/codex/tasks/task_e_6895140613688321ab8c1ddd36d6acfb