### PR TITLE
Make camera trigger endpoint configurable

### DIFF
--- a/sensor-modules/cameras/bubblecam/config.py
+++ b/sensor-modules/cameras/bubblecam/config.py
@@ -29,6 +29,11 @@ FPS = 8
 BACKLIGHT = 1
 CAMERA_ID = 0
 
+########### Server Constants ###########
+# IP address and port of the trigger publisher
+SERVER_IP = "192.168.100.2"
+SERVER_PORT = 5555
+
 ########### Logging Constants ###########
 # Name of file to log to
 LOG_FILE = "bcam"

--- a/sensor-modules/cameras/bubblecam/main.py
+++ b/sensor-modules/cameras/bubblecam/main.py
@@ -12,6 +12,7 @@ sys.path.append(str(COMMON_DIR))
 
 from bubblecam import BubbleCam
 from state import State
+import config
 
 if __name__ == "__main__":
     prev_state = State.QUIESCENT
@@ -25,7 +26,7 @@ if __name__ == "__main__":
     # ZMQ subscriber listens for trigger events from the conductivity UI
     context = zmq.Context()
     socket = context.socket(zmq.SUB)
-    socket.connect("tcp://192.168.100.2:5555")
+    socket.connect(f"tcp://{config.SERVER_IP}:{config.SERVER_PORT}")
     socket.setsockopt(zmq.SUBSCRIBE, b"trigger")
 
     capture_thread = threading.Thread(target=bubblecam.capture_loop, args=(queue, lock))

--- a/sensor-modules/cameras/foamcam/config.py
+++ b/sensor-modules/cameras/foamcam/config.py
@@ -29,6 +29,11 @@ FPS = 8
 BACKLIGHT = 1
 CAMERA_ID = 1
 
+########### Server Constants ###########
+# IP address and port of the trigger publisher
+SERVER_IP = "192.168.100.2"
+SERVER_PORT = 5555
+
 ########### Logging Constants ###########
 # Name of file to log to
 LOG_FILE = "fcam"

--- a/sensor-modules/cameras/foamcam/main.py
+++ b/sensor-modules/cameras/foamcam/main.py
@@ -12,6 +12,7 @@ sys.path.append(str(COMMON_DIR))
 
 from foamcam import FoamCam
 from state import State
+import config
 
 
 if __name__ == "__main__":
@@ -25,7 +26,7 @@ if __name__ == "__main__":
 
     context = zmq.Context()
     socket = context.socket(zmq.SUB)
-    socket.connect("tcp://192.168.100.2:5555")
+    socket.connect(f"tcp://{config.SERVER_IP}:{config.SERVER_PORT}")
     socket.setsockopt(zmq.SUBSCRIBE, b"trigger")
 
     capture_thread = threading.Thread(target=foamcam.capture_loop, args=(queue, lock))


### PR DESCRIPTION
## Summary
- Read ZMQ trigger server IP and port from each camera's `config.py`
- Use new configuration in bubblecam and foamcam main scripts

## Testing
- `pytest sensor-modules/cameras/bubblecam/tests -q` *(fails: ImportError: attempted relative import beyond top-level package; ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_689523e484c083218d8ed3099b2cd91c