### PR TITLE
Harden whitecapcam against camera disconnects

### DIFF
--- a/sensor-modules/cameras/whitecapcam/tests/test_capture_retry.py
+++ b/sensor-modules/cameras/whitecapcam/tests/test_capture_retry.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+import whitecapcam.whitecapcam as whitecapcam
+
+
+def test_capture_resets_and_retries(monkeypatch, tmp_path):
+    """WhiteCapCam should reset and retry when a capture fails."""
+
+    class DummyCam:
+        def __init__(self, *args, **kwargs):
+            # First call fails, second succeeds
+            self.capture_image = MagicMock(side_effect=[(False, None), (True, "frame")])
+            self.reset = MagicMock()
+            self.power_off = MagicMock()
+
+    # Replace the real Cam with our dummy implementation
+    monkeypatch.setattr(whitecapcam, "Cam", DummyCam)
+
+    # Stub out cv2.imwrite so no files are actually written
+    monkeypatch.setattr(whitecapcam.cv2, "imwrite", MagicMock())
+
+    cam = whitecapcam.WhiteCapCam()
+    cam.config.IMG_DIR = tmp_path
+
+    cam.capture()
+
+    assert cam.cam.capture_image.call_count == 2
+    assert cam.cam.reset.call_count == 1
+    whitecapcam.cv2.imwrite.assert_called_once()
+

--- a/sensor-modules/cameras/whitecapcam/whitecapcam.py
+++ b/sensor-modules/cameras/whitecapcam/whitecapcam.py
@@ -1,5 +1,6 @@
 import datetime
 import sys
+import time
 from pathlib import Path
 import cv2
 
@@ -36,18 +37,39 @@ class WhiteCapCam:
         )
 
     def capture(self) -> None:
-        """Capture a single image and save to disk."""
-        success, frame = self.cam.capture_image()
-        if not success or frame is None:
-            self.logger.warning("Failed to capture image")
-            return
+        """Capture a single image and save to disk.
 
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        img_dir = Path(self.config.IMG_DIR)
-        img_dir.mkdir(parents=True, exist_ok=True)
-        img_path = img_dir / f"{timestamp}{self.config.IMG_TYPE}"
-        cv2.imwrite(str(img_path), frame)
-        self.logger.info("Captured image %s", img_path)
+        The camera connection can occasionally drop out briefly.  Similar to
+        the BubbleCam and FoamCam workflows, this method retries the capture a
+        few times, resetting the underlying camera if necessary.
+        """
+
+        for attempt in range(3):
+            try:
+                success, frame = self.cam.capture_image()
+            except Exception as exc:  # pragma: no cover - defensive safety net
+                self.logger.error(
+                    "Camera error on capture attempt %d: %s", attempt + 1, exc
+                )
+                success, frame = False, None
+
+            if success and frame is not None:
+                timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+                img_dir = Path(self.config.IMG_DIR)
+                img_dir.mkdir(parents=True, exist_ok=True)
+                img_path = img_dir / f"{timestamp}{self.config.IMG_TYPE}"
+                cv2.imwrite(str(img_path), frame)
+                self.logger.info("Captured image %s", img_path)
+                return
+
+            self.logger.warning(
+                "Failed to capture image on attempt %d; resetting camera",
+                attempt + 1,
+            )
+            self.cam.reset()
+            time.sleep(1)
+
+        self.logger.error("All capture attempts failed; giving up")
 
     def power_off(self) -> None:
         """Power off the camera."""


### PR DESCRIPTION
## Summary
- retry whitecapcam captures and reset camera on failure
- add regression test for capture retry logic

## Testing
- `pytest sensor-modules/cameras/whitecapcam/tests/test_capture_retry.py`

------
https://chatgpt.com/codex/tasks/task_e_68952c97bc688321a3dc3361b5c69f0a