### PR TITLE
Ensure camera resources released

### DIFF
--- a/sensor-modules/cameras/common/identify_cameras.py
+++ b/sensor-modules/cameras/common/identify_cameras.py
@@ -23,7 +23,9 @@ def enumerate_cameras() -> List[str]:
         cam = cam_list.GetByIndex(i)
         serial = cam.TLDevice.DeviceSerialNumber.GetValue()
         serials.append(serial)
+        del cam
     cam_list.Clear()
+    del cam_list
     system.ReleaseInstance()
     return serials
 
@@ -47,6 +49,7 @@ def preview_camera(serial: str) -> None:
         if cv2.waitKey(1) & 0xFF == ord('q'):
             break
     cap.release()
+    del cap
     cv2.destroyWindow(window)
 
 


### PR DESCRIPTION
## Summary
- Release temporary camera handles during enumeration to free resources
- Clear and delete the camera list before releasing the PySpin system instance
- Fully release preview VideoCapture objects by deleting them after cap.release

## Testing
- `pytest` *(fails: ImportError: attempted relative import beyond top-level package, ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_6896721525bc832198f68a04ef363a18